### PR TITLE
Changed eof identification

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ module.exports = {
             //NAME      ACTIVE   DRIVER       STATE     URL                         SWARM   DOCKER    ERRORS
             //default   -        virtualbox   Running   tcp://192.168.99.100:2376           v1.10.3
 
-
-            var lines = stdout.split(os.EOL);
+            //remove all end of line
+            var lines = stdout.split(/\r?\n/);
 
 
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,4 +1,5 @@
-var should = require('chai').should(),
+var should = require('chai').should()
+var expect = require('chai').expect;
 machine = require('../index');
 
 var softlayerUser = process.env.SL_USER;
@@ -25,37 +26,6 @@ var options = {
 
 var machineName = "mochatest";
 
-describe('#ls',function() {
-	it('lists out some machines', function(done) {
-        machine.ls().then(
-            function (output) {
-                console.log(output);
-                output.should.be.instanceof(Array);
-                done();
-            }
-        ).fail(function(err){
-
-            done(err);
-        })
-
-    });
-
-    it('lists out some machines using a callback', function(done) {
-        machine.ls(function (err,result) {
-
-            if(err) {
-                err.should.not.exist;
-                done();
-            }
-
-            result.should.be.instanceof(Array);
-            done();
-        })
-
-    });
-
-});
-
 
 describe('#create',function() {
 
@@ -78,7 +48,38 @@ describe('#create',function() {
     });
 });
 
+describe('#ls',function() {
+    it('lists out some machines', function(done) {
+        machine.ls().then(
+            function (output) {
+                console.log(output);
+                output.should.be.instanceof(Array);
+                expect(output).to.have.length.above(0);
+                done();
+            }
+        ).fail(function(err){
 
+            done(err);
+        })
+
+    });
+
+    it('lists out some machines using a callback', function(done) {
+        machine.ls(function (err,result) {
+
+            if(err) {
+                err.should.not.exist;
+                done();
+            }
+
+            result.should.be.instanceof(Array);
+            expect(result).to.have.length.above(0);
+            done();
+        })
+
+    });
+
+});
 
 describe('#active',function() {
 


### PR DESCRIPTION
This module is great for what I wanted to build, but on docker-toolbox for windows 7 it didn't split according to the newline character. So the machine.ls function would always return `[]` since it considered the entire `exec docker-machine ls` output to be the header text.

Another change that may be of use is that I propose changing the ordering of the test functions. Your testers always passed `ls` as valid even though it returned `[]` since it only checked for the object type. This way another check for whether `ls` is working as expected by seeing that it accounts for `mochaTest`.